### PR TITLE
[HttpClient] Make `CachingHttpClient` compatible with RFC 9111

### DIFF
--- a/UPGRADE-7.4.md
+++ b/UPGRADE-7.4.md
@@ -57,6 +57,7 @@ HttpClient
 ----------
 
  * Deprecate using amphp/http-client < 5
+ * Deprecate passing an instance of `StoreInterface` as `$cache` argument to `CachingHttpClient` constructor
 
 HttpFoundation
 --------------

--- a/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
+++ b/src/Symfony/Bundle/FrameworkBundle/CHANGELOG.md
@@ -12,6 +12,7 @@ CHANGELOG
  * Add `framework.type_info.aliases` option
  * Add `KernelBrowser::getSession()`
  * Add support for configuring workflow places with glob patterns matching consts/backed enums
+ * Add support for configuring the `CachingHttpClient`
 
 7.3
 ---

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/Configuration.php
@@ -1995,6 +1995,7 @@ class Configuration implements ConfigurationInterface
                                     ->defaultNull()
                                     ->info('Rate limiter name to use for throttling requests.')
                                 ->end()
+                                ->append($this->createHttpClientCachingSection())
                                 ->append($this->createHttpClientRetrySection())
                             ->end()
                         ->end()
@@ -2140,6 +2141,7 @@ class Configuration implements ConfigurationInterface
                                         ->defaultNull()
                                         ->info('Rate limiter name to use for throttling requests.')
                                     ->end()
+                                    ->append($this->createHttpClientCachingSection())
                                     ->append($this->createHttpClientRetrySection())
                                 ->end()
                             ->end()
@@ -2148,6 +2150,33 @@ class Configuration implements ConfigurationInterface
                 ->end()
             ->end()
         ;
+    }
+
+    private function createHttpClientCachingSection(): ArrayNodeDefinition
+    {
+        $root = new NodeBuilder();
+
+        return $root
+            ->arrayNode('caching')
+                ->info('Caching configuration.')
+                ->canBeEnabled()
+                ->addDefaultsIfNotSet()
+                ->children()
+                    ->stringNode('cache_pool')
+                        ->info('The taggable cache pool to use for storing the responses.')
+                        ->defaultValue('cache.http_client')
+                        ->cannotBeEmpty()
+                    ->end()
+                    ->booleanNode('shared')
+                        ->info('Indicates whether the cache is shared (public) or private.')
+                        ->defaultTrue()
+                    ->end()
+                    ->integerNode('max_ttl')
+                        ->info('The maximum TTL (in seconds) allowed for cached responses. Null means no cap.')
+                        ->defaultNull()
+                        ->min(0)
+                    ->end()
+                ->end();
     }
 
     private function createHttpClientRetrySection(): ArrayNodeDefinition

--- a/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
+++ b/src/Symfony/Bundle/FrameworkBundle/DependencyInjection/FrameworkExtension.php
@@ -93,6 +93,8 @@ use Symfony\Component\Form\FormTypeInterface;
 use Symfony\Component\HtmlSanitizer\HtmlSanitizer;
 use Symfony\Component\HtmlSanitizer\HtmlSanitizerConfig;
 use Symfony\Component\HtmlSanitizer\HtmlSanitizerInterface;
+use Symfony\Component\HttpClient\CachingHttpClient;
+use Symfony\Component\HttpClient\Exception\ChunkCacheItemNotFoundException;
 use Symfony\Component\HttpClient\Messenger\PingWebhookMessageHandler;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Retry\GenericRetryStrategy;
@@ -2770,6 +2772,8 @@ class FrameworkExtension extends Extension
         $loader->load('http_client.php');
 
         $options = $config['default_options'] ?? [];
+        $cachingOptions = $options['caching'] ?? ['enabled' => false];
+        unset($options['caching']);
         $rateLimiter = $options['rate_limiter'] ?? null;
         unset($options['rate_limiter']);
         $retryOptions = $options['retry_failed'] ?? ['enabled' => false];
@@ -2791,6 +2795,10 @@ class FrameworkExtension extends Extension
             $container->removeDefinition('httplug.http_client');
             $container->removeAlias(HttpAsyncClient::class);
             $container->removeAlias(HttpClient::class);
+        }
+
+        if ($this->readConfigEnabled('http_client.caching', $container, $cachingOptions)) {
+            $this->registerCachingHttpClient($cachingOptions, $options, 'http_client', $container);
         }
 
         if (null !== $rateLimiter) {
@@ -2818,6 +2826,8 @@ class FrameworkExtension extends Extension
 
             $scope = $scopeConfig['scope'] ?? null;
             unset($scopeConfig['scope']);
+            $cachingOptions = $scopeConfig['caching'] ?? ['enabled' => false];
+            unset($scopeConfig['caching']);
             $rateLimiter = $scopeConfig['rate_limiter'] ?? null;
             unset($scopeConfig['rate_limiter']);
             $retryOptions = $scopeConfig['retry_failed'] ?? ['enabled' => false];
@@ -2839,6 +2849,10 @@ class FrameworkExtension extends Extension
                     ->addTag('http_client.client')
                     ->addTag('kernel.reset', ['method' => 'reset', 'on_invalid' => 'ignore'])
                 ;
+            }
+
+            if ($this->readConfigEnabled('http_client.scoped_clients.'.$name.'.caching', $container, $cachingOptions)) {
+                $this->registerCachingHttpClient($cachingOptions, $scopeConfig, $name, $container);
             }
 
             if (null !== $rateLimiter) {
@@ -2880,6 +2894,24 @@ class FrameworkExtension extends Extension
                 ->setDecoratedService('http_client.transport', null, -10)  // lower priority than TraceableHttpClient (5)
                 ->setArguments([new Reference($responseFactoryId)]);
         }
+    }
+
+    private function registerCachingHttpClient(array $options, array $defaultOptions, string $name, ContainerBuilder $container): void
+    {
+        if (!class_exists(ChunkCacheItemNotFoundException::class)) {
+            throw new LogicException('Caching cannot be enabled as version 7.3+ of the HttpClient component is required.');
+        }
+
+        $container
+            ->register($name.'.caching', CachingHttpClient::class)
+            ->setDecoratedService($name, null, 13) // between RetryableHttpClient (10) and ThrottlingHttpClient (15)
+            ->setArguments([
+                new Reference($name.'.caching.inner'),
+                new Reference($options['cache_pool']),
+                $defaultOptions,
+                $options['shared'],
+                $options['max_ttl'],
+            ]);
     }
 
     private function registerThrottlingHttpClient(string $rateLimiter, string $name, ContainerBuilder $container): void

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/http_client.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/http_client.php
@@ -15,6 +15,7 @@ use Http\Client\HttpAsyncClient;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
+use Symfony\Component\Cache\Adapter\TagAwareAdapter;
 use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Component\HttpClient\HttplugClient;
 use Symfony\Component\HttpClient\Messenger\PingWebhookMessageHandler;
@@ -25,6 +26,14 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 return static function (ContainerConfigurator $container) {
     $container->services()
+        ->set('cache.http_client.pool')
+            ->parent('cache.app')
+            ->tag('cache.pool')
+
+        ->set('cache.http_client', TagAwareAdapter::class)
+            ->args([service('cache.http_client.pool')])
+            ->tag('cache.taggable', ['pool' => 'cache.http_client.pool'])
+
         ->set('http_client.transport', HttpClientInterface::class)
             ->factory([HttpClient::class, 'create'])
             ->args([

--- a/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
+++ b/src/Symfony/Bundle/FrameworkBundle/Resources/config/schema/symfony-1.0.xsd
@@ -730,6 +730,7 @@
             <xsd:element name="header" type="http_header" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="var" type="http_var" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="peer-fingerprint" type="fingerprint" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="caching" type="http_client_caching" minOccurs="0" maxOccurs="1" />
             <xsd:element name="retry-failed" type="http_client_retry_failed" minOccurs="0" maxOccurs="1" />
             <xsd:element name="extra" type="xsd:anyType" minOccurs="0" maxOccurs="unbounded" />
         </xsd:choice>
@@ -757,6 +758,7 @@
             <xsd:element name="resolve" type="http_resolve" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="header" type="http_header" minOccurs="0" maxOccurs="unbounded" />
             <xsd:element name="peer-fingerprint" type="fingerprint" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:element name="caching" type="http_client_caching" minOccurs="0" maxOccurs="1" />
             <xsd:element name="retry-failed" type="http_client_retry_failed" minOccurs="0" maxOccurs="1" />
             <xsd:element name="extra" type="xsd:anyType" minOccurs="0" maxOccurs="unbounded" />
         </xsd:choice>
@@ -788,6 +790,13 @@
             <xsd:element name="sha1" type="xsd:string" minOccurs="0" />
             <xsd:element name="md5" type="xsd:string" minOccurs="0" />
         </xsd:choice>
+    </xsd:complexType>
+
+    <xsd:complexType name="http_client_caching">
+        <xsd:attribute name="enabled" type="xsd:boolean" />
+        <xsd:attribute name="cache-pool" type="xsd:string" />
+        <xsd:attribute name="shared" type="xsd:boolean" />
+        <xsd:attribute name="max-ttl" type="xsd:unsignedInt" />
     </xsd:complexType>
 
     <xsd:complexType name="http_client_retry_failed">

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_caching.php
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/php/http_client_caching.php
@@ -1,0 +1,24 @@
+<?php
+
+$container->loadFromExtension('framework', [
+    'annotations' => false,
+    'http_method_override' => false,
+    'handle_all_throwables' => true,
+    'php_errors' => ['log' => true],
+    'http_client' => [
+        'default_options' => [
+            'headers' => ['X-powered' => 'PHP'],
+            'caching' => [
+                'cache_pool' => 'foo',
+                'shared' => false,
+                'max_ttl' => 2,
+            ],
+        ],
+        'scoped_clients' => [
+            'bar' => [
+                'base_uri' => 'http://example.com',
+                'caching' => ['cache_pool' => 'baz'],
+            ],
+        ],
+    ],
+]);

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_caching.xml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/xml/http_client_caching.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:framework="http://symfony.com/schema/dic/symfony"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd
+        http://symfony.com/schema/dic/symfony http://symfony.com/schema/dic/symfony/symfony-1.0.xsd">
+
+    <framework:config http-method-override="false" handle-all-throwables="true">
+        <framework:annotations enabled="false" />
+        <framework:php-errors log="true" />
+        <framework:http-client>
+            <framework:default-options>
+                <framework:header name="X-powered">PHP</framework:header>
+                <framework:caching enabled="true" cache-pool="foo" shared="false" max-ttl="2"/>
+            </framework:default-options>
+            <framework:scoped-client name="bar" base-uri="http://example.com">
+                <framework:caching cache-pool="baz"/>
+            </framework:scoped-client>
+        </framework:http-client>
+    </framework:config>
+</container>

--- a/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_caching.yml
+++ b/src/Symfony/Bundle/FrameworkBundle/Tests/DependencyInjection/Fixtures/yml/http_client_caching.yml
@@ -1,0 +1,19 @@
+framework:
+  annotations: false
+  http_method_override: false
+  handle_all_throwables: true
+  php_errors:
+    log: true
+  http_client:
+    default_options:
+      headers:
+        X-powered: PHP
+      caching:
+        cache_pool: foo
+        shared: false
+        max_ttl: 2
+    scoped_clients:
+      bar:
+        base_uri: http://example.com
+        caching:
+          cache_pool: baz

--- a/src/Symfony/Component/HttpClient/CHANGELOG.md
+++ b/src/Symfony/Component/HttpClient/CHANGELOG.md
@@ -5,6 +5,8 @@ CHANGELOG
 ---
 
  * Deprecate using amphp/http-client < 5
+ * Add RFC 9111–based caching support to `CachingHttpClient`
+ * Deprecate passing an instance of `StoreInterface` as `$cache` argument to `CachingHttpClient` constructor
 
 7.3
 ---

--- a/src/Symfony/Component/HttpClient/Caching/Freshness.php
+++ b/src/Symfony/Component/HttpClient/Caching/Freshness.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Caching;
+
+/**
+ * @internal
+ */
+enum Freshness
+{
+    /**
+     * The cached response is fresh and can be used without revalidation.
+     */
+    case Fresh;
+    /**
+     * The cached response is stale and must be revalidated before use.
+     */
+    case MustRevalidate;
+    /**
+     * The cached response is stale and should not be used.
+     */
+    case Stale;
+    /**
+     * The cached response is stale but may be used as a fallback in case of errors.
+     */
+    case StaleButUsable;
+}

--- a/src/Symfony/Component/HttpClient/CachingHttpClient.php
+++ b/src/Symfony/Component/HttpClient/CachingHttpClient.php
@@ -11,55 +11,132 @@
 
 namespace Symfony\Component\HttpClient;
 
+use Symfony\Component\HttpClient\Caching\Freshness;
+use Symfony\Component\HttpClient\Chunk\ErrorChunk;
+use Symfony\Component\HttpClient\Exception\ChunkCacheItemNotFoundException;
+use Symfony\Component\HttpClient\Response\AsyncContext;
+use Symfony\Component\HttpClient\Response\AsyncResponse;
 use Symfony\Component\HttpClient\Response\MockResponse;
 use Symfony\Component\HttpClient\Response\ResponseStream;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\HttpCache\HttpCache;
 use Symfony\Component\HttpKernel\HttpCache\StoreInterface;
 use Symfony\Component\HttpKernel\HttpClientKernel;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+use Symfony\Contracts\HttpClient\ChunkInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 use Symfony\Contracts\HttpClient\ResponseStreamInterface;
 use Symfony\Contracts\Service\ResetInterface;
 
 /**
- * Adds caching on top of an HTTP client.
+ * Adds caching on top of an HTTP client (per RFC 9111).
  *
- * The implementation buffers responses in memory and doesn't stream directly from the network.
- * You can disable/enable this layer by setting option "no_cache" under "extra" to true/false.
- * By default, caching is enabled unless the "buffer" option is set to false.
+ * Known omissions / partially supported features per RFC 9111:
+ *   1. Range requests:
+ *     - All range requests ("partial content") are passed through and never cached.
+ *   2. stale-while-revalidate:
+ *     - There's no actual "background revalidation" for stale responses, they will
+ *       always be revalidated.
+ *   3. min-fresh, max-stale, only-if-cached:
+ *     - Request directives are not parsed; the client ignores them.
  *
- * @author Nicolas Grekas <p@tchwork.com>
+ * @see https://www.rfc-editor.org/rfc/rfc9111
  */
 class CachingHttpClient implements HttpClientInterface, ResetInterface
 {
+    use AsyncDecoratorTrait {
+        stream as asyncStream;
+        AsyncDecoratorTrait::withOptions insteadof HttpClientTrait;
+    }
     use HttpClientTrait;
 
-    private HttpCache $cache;
+    /**
+     * The status codes that are always cacheable.
+     */
+    private const CACHEABLE_STATUS_CODES = [200, 203, 204, 300, 301, 404, 410];
+    /**
+     * The status codes that are cacheable if the response carries explicit cache directives.
+     */
+    private const CONDITIONALLY_CACHEABLE_STATUS_CODES = [302, 303, 307, 308];
+    /**
+     * The HTTP methods that are always cacheable.
+     */
+    private const CACHEABLE_METHODS = ['GET', 'HEAD'];
+    /**
+     * The HTTP methods that will trigger a cache invalidation.
+     */
+    private const UNSAFE_METHODS = ['POST', 'PUT', 'DELETE', 'PATCH'];
+    /**
+     * Headers that influence the response and may affect caching behavior.
+     */
+    private const RESPONSE_INFLUENCING_HEADERS = [
+        'accept' => true,
+        'accept-charset' => true,
+        'accept-encoding' => true,
+        'accept-language' => true,
+        'authorization' => true,
+        'cookie' => true,
+        'expect' => true,
+        'host' => true,
+        'user-agent' => true,
+    ];
+    /**
+     * Headers that MUST NOT be stored as per RFC 9111 Section 3.1.
+     */
+    private const EXCLUDED_HEADERS = [
+        'connection' => true,
+        'proxy-authenticate' => true,
+        'proxy-authentication-info' => true,
+        'proxy-authorization' => true,
+    ];
+    /**
+     * Maximum heuristic freshness lifetime in seconds (24 hours).
+     */
+    private const MAX_HEURISTIC_FRESHNESS_TTL = 86400;
+
+    private TagAwareCacheInterface|HttpCache $cache;
     private array $defaultOptions = self::OPTIONS_DEFAULTS;
 
+    /**
+     * @param bool     $sharedCache Indicates whether this cache is shared or private. When true, responses
+     *                              may be skipped from caching in presence of certain headers
+     *                              (e.g. Authorization) unless explicitly marked as public.
+     * @param int|null $maxTtl      The maximum time-to-live (in seconds) for cached responses.
+     *                              If a server-provided TTL exceeds this value, it will be capped
+     *                              to this maximum.
+     */
     public function __construct(
         private HttpClientInterface $client,
-        StoreInterface $store,
+        TagAwareCacheInterface|StoreInterface $cache,
         array $defaultOptions = [],
+        private readonly bool $sharedCache = true,
+        private readonly ?int $maxTtl = null,
     ) {
-        if (!class_exists(HttpClientKernel::class)) {
-            throw new \LogicException(\sprintf('Using "%s" requires the HttpKernel component, try running "composer require symfony/http-kernel".', __CLASS__));
+        if ($cache instanceof StoreInterface) {
+            trigger_deprecation('symfony/http-client', '7.4', 'Passing a "%s" as constructor\'s 2nd argument of "%s" is deprecated, "%s" expected.', StoreInterface::class, __CLASS__, TagAwareCacheInterface::class);
+
+            if (!class_exists(HttpClientKernel::class)) {
+                throw new \LogicException(\sprintf('Using "%s" requires the HttpKernel component, try running "composer require symfony/http-kernel".', __CLASS__));
+            }
+
+            $kernel = new HttpClientKernel($client);
+            $this->cache = new HttpCache($kernel, $cache, null, $defaultOptions);
+
+            unset($defaultOptions['debug']);
+            unset($defaultOptions['default_ttl']);
+            unset($defaultOptions['private_headers']);
+            unset($defaultOptions['skip_response_headers']);
+            unset($defaultOptions['allow_reload']);
+            unset($defaultOptions['allow_revalidate']);
+            unset($defaultOptions['stale_while_revalidate']);
+            unset($defaultOptions['stale_if_error']);
+            unset($defaultOptions['trace_level']);
+            unset($defaultOptions['trace_header']);
+        } else {
+            $this->cache = $cache;
         }
-
-        $kernel = new HttpClientKernel($client);
-        $this->cache = new HttpCache($kernel, $store, null, $defaultOptions);
-
-        unset($defaultOptions['debug']);
-        unset($defaultOptions['default_ttl']);
-        unset($defaultOptions['private_headers']);
-        unset($defaultOptions['skip_response_headers']);
-        unset($defaultOptions['allow_reload']);
-        unset($defaultOptions['allow_revalidate']);
-        unset($defaultOptions['stale_while_revalidate']);
-        unset($defaultOptions['stale_if_error']);
-        unset($defaultOptions['trace_level']);
-        unset($defaultOptions['trace_header']);
 
         if ($defaultOptions) {
             [, $this->defaultOptions] = self::prepareRequest(null, null, $defaultOptions, $this->defaultOptions);
@@ -68,11 +145,292 @@ class CachingHttpClient implements HttpClientInterface, ResetInterface
 
     public function request(string $method, string $url, array $options = []): ResponseInterface
     {
-        [$url, $options] = $this->prepareRequest($method, $url, $options, $this->defaultOptions, true);
+        if ($this->cache instanceof HttpCache) {
+            return $this->legacyRequest($method, $url, $options);
+        }
+
+        [$fullUrl, $options] = self::prepareRequest($method, $url, $options, $this->defaultOptions);
+
+        $fullUrl = implode('', $fullUrl);
+        $fullUrlTag = self::hash($fullUrl);
+
+        if ('' !== $options['body'] || ($options['extra']['no_cache'] ?? false) || isset($options['normalized_headers']['range']) || !\in_array($method, self::CACHEABLE_METHODS, true)) {
+            return new AsyncResponse($this->client, $method, $url, $options, function (ChunkInterface $chunk, AsyncContext $context) use ($method, $fullUrlTag): \Generator {
+                if (null !== $chunk->getError() || $chunk->isTimeout() || !$chunk->isFirst()) {
+                    yield $chunk;
+
+                    return;
+                }
+
+                $statusCode = $context->getStatusCode();
+                if ($statusCode >= 100 && $statusCode < 400 && \in_array($method, self::UNSAFE_METHODS, true)) {
+                    $this->cache->invalidateTags([$fullUrlTag]);
+                }
+
+                $context->passthru();
+
+                yield $chunk;
+            });
+        }
+
+        $requestHash = self::hash($method.$fullUrl.serialize(array_intersect_key($options['normalized_headers'], self::RESPONSE_INFLUENCING_HEADERS)));
+        $varyKey = "vary_{$requestHash}";
+        $varyFields = $this->cache->get($varyKey, static fn ($item, &$save): array => ($save = false) ?: [], 0);
+
+        $metadataKey = self::getMetadataKey($requestHash, $options['normalized_headers'], $varyFields);
+        $cachedData = $this->cache->get($metadataKey, static fn ($item, &$save): array => ($save = false) ?: [], 0);
+
+        $freshness = null;
+        if ($cachedData) {
+            $freshness = $this->evaluateCacheFreshness($cachedData);
+
+            if (Freshness::Fresh === $freshness) {
+                return $this->createResponseFromCache($cachedData, $method, $url, $options, $metadataKey);
+            }
+
+            if (isset($cachedData['headers']['etag'])) {
+                $options['headers']['If-None-Match'] = implode(', ', $cachedData['headers']['etag']);
+            }
+
+            if (isset($cachedData['headers']['last-modified'][0])) {
+                $options['headers']['If-Modified-Since'] = $cachedData['headers']['last-modified'][0];
+            }
+        }
+
+        // consistent expiration time for all items
+        $expiresAt = null === $this->maxTtl ? null : \DateTimeImmutable::createFromFormat('U', time() + $this->maxTtl);
+
+        return new AsyncResponse(
+            $this->client,
+            $method,
+            $url,
+            $options,
+            function (ChunkInterface $chunk, AsyncContext $context) use (
+                $expiresAt,
+                $fullUrlTag,
+                $requestHash,
+                $varyKey,
+                $varyFields,
+                &$metadataKey,
+                $cachedData,
+                $freshness,
+                $url,
+                $method,
+                $options,
+            ): \Generator {
+                static $attemptTag = null;
+                static $firstChunkKey = null;
+                static $chunkKey = null;
+
+                if (null !== $chunk->getError() || $chunk->isTimeout()) {
+                    null !== $attemptTag && $this->cache->invalidateTags([$attemptTag]);
+
+                    if (Freshness::StaleButUsable === $freshness) {
+                        // avoid throwing exception in ErrorChunk#__destruct()
+                        $chunk instanceof ErrorChunk && $chunk->didThrow(true);
+                        $context->passthru();
+                        $context->replaceResponse($this->createResponseFromCache($cachedData, $method, $url, $options, $metadataKey));
+
+                        return;
+                    }
+
+                    if (Freshness::MustRevalidate === $freshness) {
+                        // avoid throwing exception in ErrorChunk#__destruct()
+                        $chunk instanceof ErrorChunk && $chunk->didThrow(true);
+                        $context->passthru();
+                        $context->replaceResponse(self::createGatewayTimeoutResponse($method, $url, $options));
+
+                        return;
+                    }
+
+                    yield $chunk;
+
+                    return;
+                }
+
+                $headers = $context->getHeaders();
+
+                if ($chunk->isFirst()) {
+                    $statusCode = $context->getStatusCode();
+                    $cacheControl = self::parseCacheControlHeader($headers['cache-control'] ?? []);
+
+                    $attemptTag = self::generateChunkKey();
+
+                    if (304 === $statusCode && null !== $freshness) {
+                        $maxAge = $this->determineMaxAge($headers, $cacheControl);
+
+                        $this->cache->get($metadataKey, static function (ItemInterface $item) use ($headers, $maxAge, $cachedData, $expiresAt, $fullUrlTag, $metadataKey): array {
+                            $item->expiresAt($expiresAt)->tag([$fullUrlTag, $metadataKey]);
+
+                            $cachedData['expires_at'] = self::calculateExpiresAt($maxAge);
+                            $cachedData['stored_at'] = time();
+                            $cachedData['initial_age'] = (int) ($headers['age'][0] ?? 0);
+                            $cachedData['headers'] = array_merge($cachedData['headers'], array_diff_key($headers, self::EXCLUDED_HEADERS));
+
+                            return $cachedData;
+                        }, \INF);
+
+                        $context->passthru();
+                        $context->replaceResponse($this->createResponseFromCache($cachedData, $method, $url, $options, $metadataKey));
+
+                        return;
+                    }
+
+                    if ($statusCode >= 500 && $statusCode < 600) {
+                        if (Freshness::StaleButUsable === $freshness) {
+                            $context->passthru();
+                            $context->replaceResponse($this->createResponseFromCache($cachedData, $method, $url, $options, $metadataKey));
+
+                            return;
+                        }
+
+                        if (Freshness::MustRevalidate === $freshness) {
+                            $context->passthru();
+                            $context->replaceResponse(self::createGatewayTimeoutResponse($method, $url, $options));
+
+                            return;
+                        }
+                    }
+
+                    if (!$this->isServerResponseCacheable($statusCode, $options['normalized_headers'], $headers, $cacheControl)) {
+                        $context->passthru();
+
+                        yield $chunk;
+
+                        return;
+                    }
+
+                    // recomputing vary fields in case it changed or for first request
+                    $newVaryFields = [];
+                    foreach ($headers['vary'] ?? [] as $vary) {
+                        foreach (explode(',', $vary) as $field) {
+                            $field = strtolower(trim($field));
+                            if ('cookie' === $field ? $this->sharedCache : !preg_match('/^[!#$%&\'*+\-.^_`|~0-9A-Za-z]+$/D', $field)) {
+                                $field = '*';
+                            }
+                            $newVaryFields[] = $field;
+                        }
+                    }
+
+                    if (\in_array('*', $newVaryFields, true)) {
+                        $context->passthru();
+
+                        yield $chunk;
+
+                        return;
+                    }
+
+                    sort($newVaryFields);
+
+                    if ($varyFields !== $newVaryFields) {
+                        $this->cache->invalidateTags([$fullUrlTag]);
+
+                        $metadataKey = self::getMetadataKey($requestHash, $options['normalized_headers'], $newVaryFields);
+                    }
+
+                    $this->cache->get($varyKey, static function (ItemInterface $item) use ($newVaryFields, $expiresAt, $fullUrlTag): array {
+                        $item->tag([$fullUrlTag])->expiresAt($expiresAt);
+
+                        return $newVaryFields;
+                    }, \INF);
+
+                    $firstChunkKey = $chunkKey = self::generateChunkKey();
+
+                    yield $chunk;
+
+                    return;
+                }
+
+                if (null === $chunkKey) {
+                    // informational chunks
+                    yield $chunk;
+
+                    return;
+                }
+
+                if ($chunk->isLast()) {
+                    $this->cache->get($chunkKey, static function (ItemInterface $item) use ($expiresAt, $fullUrlTag, $metadataKey, $chunk, $attemptTag): array {
+                        $item->tag([$fullUrlTag, $metadataKey, $attemptTag])->expiresAt($expiresAt);
+
+                        return [
+                            'content' => $chunk->getContent(),
+                            'next_chunk' => null,
+                        ];
+                    }, \INF);
+
+                    $maxAge = $this->determineMaxAge($headers, self::parseCacheControlHeader($headers['cache-control'] ?? []));
+                    $this->cache->get($metadataKey, static function (ItemInterface $item) use ($context, $headers, $maxAge, $expiresAt, $fullUrlTag, $metadataKey, $attemptTag, $firstChunkKey): array {
+                        $item->tag([$fullUrlTag, $metadataKey, $attemptTag])->expiresAt($expiresAt);
+
+                        return [
+                            'status_code' => $context->getStatusCode(),
+                            'headers' => array_diff_key($headers, self::EXCLUDED_HEADERS),
+                            'initial_age' => (int) ($headers['age'][0] ?? 0),
+                            'stored_at' => time(),
+                            'expires_at' => self::calculateExpiresAt($maxAge),
+                            'next_chunk' => $firstChunkKey,
+                        ];
+                    }, \INF);
+
+                    yield $chunk;
+
+                    return;
+                }
+
+                $nextChunkKey = self::generateChunkKey();
+                $this->cache->get($chunkKey, static function (ItemInterface $item) use ($expiresAt, $fullUrlTag, $metadataKey, $attemptTag, $chunk, $nextChunkKey): array {
+                    $item->tag([$fullUrlTag, $metadataKey, $attemptTag])->expiresAt($expiresAt);
+
+                    return [
+                        'content' => $chunk->getContent(),
+                        'next_chunk' => $nextChunkKey,
+                    ];
+                }, \INF);
+                $chunkKey = $nextChunkKey;
+
+                yield $chunk;
+            }
+        );
+    }
+
+    public function stream(ResponseInterface|iterable $responses, ?float $timeout = null): ResponseStreamInterface
+    {
+        if ($responses instanceof ResponseInterface) {
+            $responses = [$responses];
+        }
+
+        $mockResponses = [];
+        $asyncResponses = [];
+
+        foreach ($responses as $response) {
+            if ($response instanceof MockResponse) {
+                $mockResponses[] = $response;
+            } else {
+                $asyncResponses[] = $response;
+            }
+        }
+
+        if (!$mockResponses) {
+            return $this->asyncStream($asyncResponses, $timeout);
+        }
+
+        if (!$asyncResponses) {
+            return new ResponseStream(MockResponse::stream($mockResponses, $timeout));
+        }
+
+        return new ResponseStream((function () use ($mockResponses, $asyncResponses, $timeout) {
+            yield from MockResponse::stream($mockResponses, $timeout);
+            yield from $this->asyncStream($asyncResponses, $timeout);
+        })());
+    }
+
+    private function legacyRequest(string $method, string $url, array $options = []): ResponseInterface
+    {
+        [$url, $options] = self::prepareRequest($method, $url, $options, $this->defaultOptions, true);
         $url = implode('', $url);
 
         if (!empty($options['body']) || !empty($options['extra']['no_cache']) || !\in_array($method, ['GET', 'HEAD', 'OPTIONS'], true)) {
-            return $this->client->request($method, $url, $options);
+            return new AsyncResponse($this->client, $method, $url, $options);
         }
 
         $request = Request::create($url, $method);
@@ -106,41 +464,304 @@ class CachingHttpClient implements HttpClientInterface, ResetInterface
         return MockResponse::fromRequest($method, $url, $options, $response);
     }
 
-    public function stream(ResponseInterface|iterable $responses, ?float $timeout = null): ResponseStreamInterface
+    private static function hash(string $toHash): string
     {
-        if ($responses instanceof ResponseInterface) {
-            $responses = [$responses];
-        }
+        return str_replace('/', '_', base64_encode(hash('sha256', $toHash, true)));
+    }
 
-        $mockResponses = [];
-        $clientResponses = [];
+    private static function generateChunkKey(): string
+    {
+        return str_replace('/', '_', base64_encode(random_bytes(6)));
+    }
 
-        foreach ($responses as $response) {
-            if ($response instanceof MockResponse) {
-                $mockResponses[] = $response;
+    /**
+     * Generates a unique metadata key based on the request hash and varying headers.
+     *
+     * @param string                         $requestHash       A hash representing the request details
+     * @param array<string, string|string[]> $normalizedHeaders Normalized headers of the request
+     * @param string[]                       $varyFields        Headers to consider for building the variant key
+     *
+     * @return string The metadata key composed of the request hash and variant key
+     */
+    private static function getMetadataKey(string $requestHash, array $normalizedHeaders, array $varyFields): string
+    {
+        $variantKey = self::hash(self::buildVariantKey($normalizedHeaders, $varyFields));
+
+        return "metadata_{$requestHash}_{$variantKey}";
+    }
+
+    /**
+     * Build a variant key for caching, given an array of normalized headers and the vary fields.
+     *
+     * The key is an ampersand-separated string of "header=value" pairs, with
+     * the special case of "header=" for headers that are not present.
+     *
+     * @param array<string, string|string[]> $normalizedHeaders
+     * @param string[]                       $varyFields
+     */
+    private static function buildVariantKey(array $normalizedHeaders, array $varyFields): string
+    {
+        $parts = [];
+        foreach ($varyFields as $field) {
+            $lower = strtolower($field);
+            if (!isset($normalizedHeaders[$lower])) {
+                $parts[$lower] = $lower.'=';
             } else {
-                $clientResponses[] = $response;
+                $parts[$lower] = $lower.'='.implode(',', array_map(rawurlencode(...), (array) $normalizedHeaders[$lower]));
+            }
+        }
+        ksort($parts);
+
+        return implode('&', $parts);
+    }
+
+    /**
+     * Parse the Cache-Control header and return an array of directive names as keys
+     * and their values as values, or true if the directive has no value.
+     *
+     * @param array<string, string|string[]> $header The Cache-Control header as an array of strings
+     *
+     * @return array<string, string|true> The parsed Cache-Control directives
+     */
+    private static function parseCacheControlHeader(array $header): array
+    {
+        $parsed = [];
+        foreach ($header as $line) {
+            foreach (explode(',', $line) as $directive) {
+                if (str_contains($directive, '=')) {
+                    [$name, $value] = explode('=', $directive, 2);
+                    $parsed[trim($name)] = trim($value);
+                } else {
+                    $parsed[trim($directive)] = true;
+                }
             }
         }
 
-        if (!$mockResponses) {
-            return $this->client->stream($clientResponses, $timeout);
-        }
-
-        if (!$clientResponses) {
-            return new ResponseStream(MockResponse::stream($mockResponses, $timeout));
-        }
-
-        return new ResponseStream((function () use ($mockResponses, $clientResponses, $timeout) {
-            yield from MockResponse::stream($mockResponses, $timeout);
-            yield $this->client->stream($clientResponses, $timeout);
-        })());
+        return $parsed;
     }
 
-    public function reset(): void
+    /**
+     * Evaluates the freshness of a cached response based on its headers and expiration time.
+     *
+     * This method determines the state of the cached response by analyzing the Cache-Control
+     * directives and the expiration timestamp.
+     *
+     * @param array{headers: array<string, string[]>, expires_at: int|null} $data The cached response data, including headers and expiration time
+     */
+    private function evaluateCacheFreshness(array $data): Freshness
     {
-        if ($this->client instanceof ResetInterface) {
-            $this->client->reset();
+        $parseCacheControlHeader = self::parseCacheControlHeader($data['headers']['cache-control'] ?? []);
+
+        if (isset($parseCacheControlHeader['no-cache'])) {
+            return Freshness::Stale;
         }
+
+        $now = time();
+        $expires = $data['expires_at'];
+
+        if (null === $expires || $now <= $expires) {
+            return Freshness::Fresh;
+        }
+
+        if (
+            isset($parseCacheControlHeader['must-revalidate'])
+            || ($this->sharedCache && isset($parseCacheControlHeader['proxy-revalidate']))
+        ) {
+            return Freshness::MustRevalidate;
+        }
+
+        if (isset($parseCacheControlHeader['stale-if-error']) && ($now - $expires) <= (int) $parseCacheControlHeader['stale-if-error']) {
+            return Freshness::StaleButUsable;
+        }
+
+        return Freshness::Stale;
+    }
+
+    /**
+     * Determine the maximum age of the response.
+     *
+     * This method first checks for the presence of the s-maxage directive, and if
+     * present, returns its value minus the current age. If s-maxage is not present,
+     * it checks for the presence of the max-age directive, and if present, returns
+     * its value minus the current age. If neither directive is present, it checks
+     * the Expires header for a valid timestamp, and if present, returns the
+     * difference between the timestamp and the current time minus the current age.
+     *
+     * If none of the above directives or headers are present, the method returns null.
+     *
+     * @param array<string, string|string[]> $headers      An array of HTTP headers
+     * @param array<string, string|true>     $cacheControl An array of parsed Cache-Control directives
+     *
+     * @return int|null The maximum age of the response, or null if it cannot be determined
+     */
+    private function determineMaxAge(array $headers, array $cacheControl): ?int
+    {
+        $age = self::getCurrentAge($headers);
+
+        if ($this->sharedCache && isset($cacheControl['s-maxage'])) {
+            $sharedMaxAge = (int) $cacheControl['s-maxage'];
+
+            return max(0, $sharedMaxAge - $age);
+        }
+
+        if (isset($cacheControl['max-age'])) {
+            $maxAge = (int) $cacheControl['max-age'];
+
+            return max(0, $maxAge - $age);
+        }
+
+        foreach ($headers['expires'] ?? [] as $expire) {
+            if (false !== $expirationTimestamp = strtotime($expire)) {
+                $timeUntilExpiration = $expirationTimestamp - time() - $age;
+
+                return max($timeUntilExpiration, 0);
+            }
+        }
+
+        // Heuristic freshness fallback when no explicit directives are present
+        if (
+            !isset($cacheControl['no-cache'])
+            && !isset($cacheControl['no-store'])
+            && isset($headers['last-modified'])
+        ) {
+            foreach ($headers['last-modified'] as $lastModified) {
+                if (false === $lastModifiedTimestamp = strtotime($lastModified)) {
+                    continue;
+                }
+                if (0 < $secondsSinceLastModified = time() - $lastModifiedTimestamp) {
+                    // Heuristic: 10% of time since last modified, capped at max heuristic freshness
+                    $heuristicFreshnessSeconds = (int) ($secondsSinceLastModified * 0.1);
+                    $cappedHeuristicFreshness = min($heuristicFreshnessSeconds, self::MAX_HEURISTIC_FRESHNESS_TTL);
+
+                    return max(0, $cappedHeuristicFreshness - $age);
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Retrieves the current age of the response from the headers.
+     *
+     * @param array<string, string|string[]> $headers An array of HTTP headers
+     *
+     * @return int The age of the response in seconds, defaults to 0 if not present
+     */
+    private static function getCurrentAge(array $headers): int
+    {
+        return (int) ($headers['age'][0] ?? 0);
+    }
+
+    /**
+     * Calculates the expiration time of the response given the maximum age.
+     *
+     * @param int|null $maxAge The maximum age of the response in seconds, or null if it cannot be determined
+     *
+     * @return int|null The expiration time of the response as a Unix timestamp, or null if the maximum age is null
+     */
+    private static function calculateExpiresAt(?int $maxAge): ?int
+    {
+        if (null === $maxAge) {
+            return null;
+        }
+
+        return time() + $maxAge;
+    }
+
+    /**
+     * Checks if the server response is cacheable according to the HTTP 1.1
+     * specification (RFC 9111).
+     *
+     * This function will return true if the server response can be cached,
+     * false otherwise.
+     *
+     * @param array<string, string|string[]> $requestHeaders
+     * @param array<string, string|string[]> $responseHeaders
+     * @param array<string, string|true>     $cacheControl
+     */
+    private function isServerResponseCacheable(int $statusCode, array $requestHeaders, array $responseHeaders, array $cacheControl): bool
+    {
+        // no-store => skip caching
+        if (isset($cacheControl['no-store'])) {
+            return false;
+        }
+
+        if (
+            $this->sharedCache
+            && !isset($cacheControl['public']) && !isset($cacheControl['s-maxage']) && !isset($cacheControl['must-revalidate'])
+            && isset($requestHeaders['authorization'])
+        ) {
+            return false;
+        }
+
+        if ($this->sharedCache && isset($cacheControl['private'])) {
+            return false;
+        }
+
+        // Conditionals require an explicit expiration
+        if (\in_array($statusCode, self::CONDITIONALLY_CACHEABLE_STATUS_CODES, true)) {
+            return $this->hasExplicitExpiration($responseHeaders, $cacheControl);
+        }
+
+        return \in_array($statusCode, self::CACHEABLE_STATUS_CODES, true);
+    }
+
+    /**
+     * Checks if the response has an explicit expiration.
+     *
+     * This function will return true if the response has an explicit expiration
+     * time specified in the headers or in the Cache-Control directives,
+     * false otherwise.
+     *
+     * @param array<string, string|string[]> $headers
+     * @param array<string, string|true>     $cacheControl
+     */
+    private function hasExplicitExpiration(array $headers, array $cacheControl): bool
+    {
+        return isset($headers['expires'])
+            || ($this->sharedCache && isset($cacheControl['s-maxage']))
+            || isset($cacheControl['max-age']);
+    }
+
+    /**
+     * Creates a MockResponse object from cached data.
+     *
+     * This function constructs a MockResponse from the cached data, including
+     * the original request method, URL, and options, as well as the cached
+     * response headers and content. The constructed MockResponse is then
+     * returned.
+     *
+     * @param array{next_chunk: string, status_code: int, initial_age: int, headers: array<string, string|string[]>, stored_at: int} $cachedData
+     */
+    private function createResponseFromCache(array $cachedData, string $method, string $url, array $options, string $metadataKey): MockResponse
+    {
+        $cache = $this->cache;
+        $callback = static function (ItemInterface $item) use ($cache, $metadataKey): never {
+            $cache->invalidateTags([$metadataKey]);
+
+            throw new ChunkCacheItemNotFoundException(\sprintf('Missing cache item for chunk with key "%s". This indicates an internal cache inconsistency.', $item->getKey()));
+        };
+        $body = static function () use ($cache, $cachedData, $callback): \Generator {
+            while (null !== $cachedData['next_chunk']) {
+                $cachedData = $cache->get($cachedData['next_chunk'], $callback, 0);
+
+                if ('' !== $cachedData['content']) {
+                    yield $cachedData['content'];
+                }
+            }
+        };
+
+        return MockResponse::fromRequest($method, $url, $options, new MockResponse($body(), [
+            'http_code' => $cachedData['status_code'],
+            'response_headers' => [
+                'age' => $cachedData['initial_age'] + (time() - $cachedData['stored_at']),
+            ] + $cachedData['headers'],
+        ]));
+    }
+
+    private static function createGatewayTimeoutResponse(string $method, string $url, array $options): MockResponse
+    {
+        return MockResponse::fromRequest($method, $url, $options, new MockResponse('', ['http_code' => 504]));
     }
 }

--- a/src/Symfony/Component/HttpClient/Exception/ChunkCacheItemNotFoundException.php
+++ b/src/Symfony/Component/HttpClient/Exception/ChunkCacheItemNotFoundException.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Exception;
+
+final class ChunkCacheItemNotFoundException extends TransportException
+{
+}

--- a/src/Symfony/Component/HttpClient/Tests/CachingHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/CachingHttpClientTest.php
@@ -11,100 +11,936 @@
 
 namespace Symfony\Component\HttpClient\Tests;
 
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
+use Symfony\Bridge\PhpUnit\ClockMock;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Adapter\TagAwareAdapter;
+use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
 use Symfony\Component\HttpClient\CachingHttpClient;
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\AsyncResponse;
 use Symfony\Component\HttpClient\Response\MockResponse;
-use Symfony\Component\HttpKernel\HttpCache\Store;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
+#[CoversClass(CachingHttpClient::class)]
+#[Group('time-sensitive')]
 class CachingHttpClientTest extends TestCase
 {
-    public function testRequestHeaders()
+    private TagAwareAdapterInterface $cacheAdapter;
+
+    protected function setUp(): void
     {
+        parent::setUp();
+
+        $this->cacheAdapter = new TagAwareAdapter(new ArrayAdapter());
+
+        if (class_exists(ClockMock::class)) {
+            ClockMock::register(TagAwareAdapter::class);
+        }
+    }
+
+    public function testBypassCacheWhenBodyPresent()
+    {
+        // If a request has a non-empty body, caching should be bypassed.
+        $mockClient = new MockHttpClient([
+            new MockResponse('cached response', ['http_code' => 200]),
+            new MockResponse('non-cached response', ['http_code' => 200]),
+        ]);
+        $client = new CachingHttpClient($mockClient, $this->cacheAdapter);
+
+        // First request with a body; should always call underlying client.
+        $options = ['body' => 'non-empty'];
+        $client->request('GET', 'http://example.com/foo-bar', $options);
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+        self::assertSame('non-cached response', $response->getContent(), 'Request with body should bypass cache.');
+    }
+
+    public function testBypassCacheWhenRangeHeaderPresent()
+    {
+        // If a "range" header is present, caching is bypassed.
+        $mockClient = new MockHttpClient([
+            new MockResponse('first response', ['http_code' => 200]),
+            new MockResponse('second response', ['http_code' => 200]),
+        ]);
+        $client = new CachingHttpClient($mockClient, $this->cacheAdapter);
+
         $options = [
-            'headers' => [
-                'Application-Name' => 'test1234',
-                'Test-Name-Header' => 'test12345',
-            ],
+            'headers' => ['Range' => 'bytes=0-100'],
+        ];
+        $client->request('GET', 'http://example.com/foo-bar', $options);
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+        self::assertSame('second response', $response->getContent(), 'Presence of range header must bypass caching.');
+    }
+
+    public function testBypassCacheForNonCacheableMethod()
+    {
+        // Methods not in CACHEABLE_METHODS (e.g. POST) bypass caching.
+        $mockClient = new MockHttpClient([
+            new MockResponse('first response', ['http_code' => 200]),
+            new MockResponse('second response', ['http_code' => 200]),
+        ]);
+        $client = new CachingHttpClient($mockClient, $this->cacheAdapter);
+
+        $client->request('POST', 'http://example.com/foo-bar');
+        $response = $client->request('POST', 'http://example.com/foo-bar');
+        self::assertSame('second response', $response->getContent(), 'Non-cacheable method must bypass caching.');
+    }
+
+    public function testItServesResponseFromCache()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', [
+                'http_code' => 200,
+            ]),
+            new MockResponse('should not be served'),
+        ]);
+
+        $client = new CachingHttpClient(
+            $mockClient,
+            $this->cacheAdapter,
+        );
+
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('foo', $response->getContent());
+
+        sleep(2);
+
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('foo', $response->getContent());
+        self::assertSame('2', $response->getHeaders()['age'][0]);
+    }
+
+    public function testItSupportsVaryHeader()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', [
+                'http_code' => 200,
+                'response_headers' => [
+                    'Vary' => 'Foo, Bar',
+                ],
+            ]),
+            new MockResponse('bar'),
+        ]);
+
+        $client = new CachingHttpClient(
+            $mockClient,
+            $this->cacheAdapter,
+        );
+
+        // Request with one set of headers.
+        $response = $client->request('GET', 'http://example.com/foo-bar', ['headers' => ['Foo' => 'foo', 'Bar' => 'bar']]);
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('foo', $response->getContent());
+
+        // Same headers: should return cached "foo".
+        $response = $client->request('GET', 'http://example.com/foo-bar', ['headers' => ['Foo' => 'foo', 'Bar' => 'bar']]);
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('foo', $response->getContent());
+
+        // Different header values: returns a new response.
+        $response = $client->request('GET', 'http://example.com/foo-bar', ['headers' => ['Foo' => 'bar', 'Bar' => 'foo']]);
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('bar', $response->getContent());
+    }
+
+    public function testItDoesntServeAStaleResponse()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', [
+                'http_code' => 200,
+                'response_headers' => [
+                    'Cache-Control' => 'max-age=5',
+                ],
+            ]),
+            new MockResponse('bar'),
+        ]);
+
+        $client = new CachingHttpClient(
+            $mockClient,
+            $this->cacheAdapter,
+        );
+
+        // The first request returns "foo".
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('foo', $response->getContent());
+
+        sleep(5);
+
+        // After 5 seconds, the cached response is still considered valid.
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('foo', $response->getContent());
+
+        sleep(1);
+
+        // After an extra second the cache expires, so a new response is served.
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('bar', $response->getContent());
+    }
+
+    public function testItRevalidatesAResponseWithNoCacheDirective()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', [
+                'http_code' => 200,
+                'response_headers' => [
+                    'Cache-Control' => 'no-cache, max-age=5',
+                ],
+            ]),
+            new MockResponse('bar'),
+        ]);
+
+        // Use a private cache (sharedCache = false) so that revalidation is performed.
+        $client = new CachingHttpClient(
+            $mockClient,
+            $this->cacheAdapter,
+            sharedCache: false,
+        );
+
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('foo', $response->getContent());
+
+        // The next request revalidates the response and should fetch "bar".
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('bar', $response->getContent());
+    }
+
+    public function testItServesAStaleResponseIfError()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', [
+                'http_code' => 404,
+                'response_headers' => [
+                    'Cache-Control' => 'max-age=1, stale-if-error=5',
+                ],
+            ]),
+            new MockResponse('Internal Server Error', ['http_code' => 500]),
+        ]);
+
+        $client = new CachingHttpClient(
+            $mockClient,
+            $this->cacheAdapter,
+            sharedCache: false,
+        );
+
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+        self::assertSame(404, $response->getStatusCode());
+        self::assertSame('foo', $response->getContent(false));
+
+        sleep(5);
+
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+        self::assertSame(404, $response->getStatusCode());
+        self::assertSame('foo', $response->getContent(false));
+    }
+
+    public function testPrivateCacheWithSharedCacheFalse()
+    {
+        $responses = [
+            new MockResponse('foo', [
+                'http_code' => 200,
+                'response_headers' => [
+                    'Cache-Control' => 'private, max-age=5',
+                ],
+            ]),
+            new MockResponse('should not be served'),
         ];
 
-        $mockClient = new MockHttpClient();
-        $store = new Store(sys_get_temp_dir().'/sf_http_cache');
-        $client = new CachingHttpClient($mockClient, $store, $options);
+        $mockHttpClient = new MockHttpClient($responses);
+        $client = new CachingHttpClient(
+            $mockHttpClient,
+            $this->cacheAdapter,
+            sharedCache: false,
+        );
+
+        $response = $client->request('GET', 'http://example.com/test-private');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('foo', $response->getContent());
+
+        $response = $client->request('GET', 'http://example.com/test-private');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('foo', $response->getContent());
+    }
+
+    public function testItDoesntStoreAResponseWithNoStoreDirective()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', [
+                'http_code' => 200,
+                'response_headers' => [
+                    'Cache-Control' => 'no-store',
+                ],
+            ]),
+            new MockResponse('bar'),
+        ]);
+
+        $client = new CachingHttpClient(
+            $mockClient,
+            $this->cacheAdapter,
+        );
+
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('foo', $response->getContent());
+
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('bar', $response->getContent());
+    }
+
+    public function testASharedCacheDoesntStoreAResponseFromRequestWithAuthorization()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', [
+                'http_code' => 200,
+            ]),
+            new MockResponse('bar'),
+        ]);
+
+        $client = new CachingHttpClient(
+            $mockClient,
+            $this->cacheAdapter,
+            [
+                'headers' => [
+                    'Authorization' => 'foo',
+                ],
+            ],
+        );
+
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('foo', $response->getContent());
+
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('bar', $response->getContent());
+    }
+
+    public function testASharedCacheStoresAResponseWithPublicDirectiveFromRequestWithAuthorization()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', [
+                'http_code' => 200,
+                'response_headers' => [
+                    'Cache-Control' => 'public',
+                ],
+            ]),
+            new MockResponse('should not be served'),
+        ]);
+
+        $client = new CachingHttpClient(
+            $mockClient,
+            $this->cacheAdapter,
+            [
+                'headers' => [
+                    'Authorization' => 'foo',
+                ],
+            ],
+            sharedCache: true,
+        );
+
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('foo', $response->getContent());
+
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('foo', $response->getContent());
+    }
+
+    public function testASharedCacheStoresAResponseWithSMaxAgeDirectiveFromRequestWithAuthorization()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', [
+                'http_code' => 200,
+                'response_headers' => [
+                    'Cache-Control' => 's-maxage=5',
+                ],
+            ]),
+            new MockResponse('should not be served'),
+        ]);
+
+        $client = new CachingHttpClient(
+            $mockClient,
+            $this->cacheAdapter,
+            [
+                'headers' => [
+                    'Authorization' => 'foo',
+                ],
+            ],
+            sharedCache: true,
+        );
+
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('foo', $response->getContent());
+
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('foo', $response->getContent());
+    }
+
+    public function testASharedCacheDoesntStoreAResponseWithPrivateDirective()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', [
+                'http_code' => 200,
+                'response_headers' => [
+                    'Cache-Control' => 'private, max-age=5',
+                ],
+            ]),
+            new MockResponse('bar'),
+        ]);
+
+        $client = new CachingHttpClient(
+            $mockClient,
+            $this->cacheAdapter,
+            sharedCache: true,
+        );
+
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('foo', $response->getContent());
+
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('bar', $response->getContent());
+    }
+
+    public function testAPrivateCacheStoresAResponseWithPrivateDirective()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', [
+                'http_code' => 200,
+                'response_headers' => [
+                    'Cache-Control' => 'private, max-age=5',
+                ],
+            ]),
+            new MockResponse('should not be served'),
+        ]);
+
+        $client = new CachingHttpClient(
+            $mockClient,
+            $this->cacheAdapter,
+            sharedCache: false,
+        );
+
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('foo', $response->getContent());
+
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('foo', $response->getContent());
+    }
+
+    public function testCacheMissAfterInvalidation()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', [
+                'http_code' => 200,
+                'response_headers' => [
+                    'Cache-Control' => 'max-age=300',
+                ],
+            ]),
+            new MockResponse('', ['http_code' => 204]),
+            new MockResponse('bar'),
+        ]);
+
+        $client = new CachingHttpClient(
+            $mockClient,
+            $this->cacheAdapter,
+        );
+
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('foo', $response->getContent());
+
+        $client->request('DELETE', 'http://example.com/foo-bar');
+
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('bar', $response->getContent());
+    }
+
+    public function testChunkErrorServesStaleResponse()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', [
+                'http_code' => 200,
+                'response_headers' => [
+                    'Cache-Control' => 'max-age=1, stale-if-error=3',
+                ],
+            ]),
+            new MockResponse('', ['error' => 'Simulated']),
+        ]);
+
+        $client = new CachingHttpClient(
+            $mockClient,
+            $this->cacheAdapter,
+        );
+
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('foo', $response->getContent());
+
+        sleep(2);
+
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('foo', $response->getContent());
+    }
+
+    public function testChunkErrorMustRevalidate()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', [
+                'http_code' => 200,
+                'response_headers' => [
+                    'Cache-Control' => 'max-age=1, must-revalidate',
+                ],
+            ]),
+            new MockResponse('', ['error' => 'Simulated']),
+        ]);
+
+        $client = new CachingHttpClient(
+            $mockClient,
+            $this->cacheAdapter,
+        );
+
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('foo', $response->getContent());
+
+        sleep(2);
+
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+        self::assertSame(504, $response->getStatusCode());
+    }
+
+    public function testExceedingMaxAgeIsCappedByTtl()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', [
+                'http_code' => 200,
+                'response_headers' => [
+                    'Cache-Control' => 'max-age=300',
+                ],
+            ]),
+            new MockResponse('bar', ['http_code' => 200]),
+        ]);
+
+        $client = new CachingHttpClient(
+            $mockClient,
+            $this->cacheAdapter,
+            maxTtl: 10,
+        );
+
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('foo', $response->getContent());
+
+        sleep(11);
+
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('bar', $response->getContent());
+    }
+
+    public function testItCanStreamAsyncResponse()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', ['http_code' => 200]),
+        ]);
+
+        $client = new CachingHttpClient(
+            $mockClient,
+            $this->cacheAdapter,
+        );
 
         $response = $client->request('GET', 'http://example.com/foo-bar');
 
-        rmdir(sys_get_temp_dir().'/sf_http_cache');
+        self::assertInstanceOf(AsyncResponse::class, $response);
+
+        $collected = '';
+        foreach ($client->stream($response) as $chunk) {
+            $collected .= $chunk->getContent();
+        }
+
+        self::assertSame('foo', $collected);
+    }
+
+    public function testItCanStreamCachedResponse()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', ['http_code' => 200]),
+        ]);
+
+        $client = new CachingHttpClient(
+            $mockClient,
+            $this->cacheAdapter,
+        );
+
+        $client->request('GET', 'http://example.com/foo-bar')->getContent(); // warm the cache
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+
         self::assertInstanceOf(MockResponse::class, $response);
-        self::assertSame($response->getRequestOptions()['normalized_headers']['application-name'][0], 'Application-Name: test1234');
-        self::assertSame($response->getRequestOptions()['normalized_headers']['test-name-header'][0], 'Test-Name-Header: test12345');
+
+        $collected = '';
+        foreach ($client->stream($response) as $chunk) {
+            $collected .= $chunk->getContent();
+        }
+
+        self::assertSame('foo', $collected);
     }
 
-    public function testDoesNotEvaluateResponseBody()
+    public function testItCanStreamBoth()
     {
-        $body = file_get_contents(__DIR__.'/Fixtures/assertion_failure.php');
-        $response = $this->runRequest(new MockResponse($body, ['response_headers' => ['X-Body-Eval' => true]]));
-        $headers = $response->getHeaders();
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', ['http_code' => 200]),
+            new MockResponse('bar', ['http_code' => 200]),
+        ]);
 
-        $this->assertSame($body, $response->getContent());
-        $this->assertArrayNotHasKey('x-body-eval', $headers);
+        $client = new CachingHttpClient(
+            $mockClient,
+            $this->cacheAdapter,
+        );
+
+        $client->request('GET', 'http://example.com/foo')->getContent(); // warm the cache
+        $cachedResponse = $client->request('GET', 'http://example.com/foo');
+        $asyncResponse = $client->request('GET', 'http://example.com/bar');
+
+        self::assertInstanceOf(MockResponse::class, $cachedResponse);
+        self::assertInstanceOf(AsyncResponse::class, $asyncResponse);
+
+        $collected = '';
+        foreach ($client->stream([$asyncResponse, $cachedResponse]) as $chunk) {
+            $collected .= $chunk->getContent();
+        }
+
+        self::assertSame('foobar', $collected);
     }
 
-    public function testDoesNotIncludeFile()
+    public function testMultipleChunksResponse()
     {
-        $file = __DIR__.'/Fixtures/assertion_failure.php';
+        $mockClient = new MockHttpClient([
+            new MockResponse(['chunk1', 'chunk2', 'chunk3'], ['http_code' => 200, 'response_headers' => ['Cache-Control' => 'max-age=5']]),
+        ]);
 
-        $response = $this->runRequest(new MockResponse(
-            'test', ['response_headers' => [
-                'X-Body-Eval' => true,
-                'X-Body-File' => $file,
-            ]]
-        ));
-        $headers = $response->getHeaders();
+        $client = new CachingHttpClient($mockClient, $this->cacheAdapter);
 
-        $this->assertSame('test', $response->getContent());
-        $this->assertArrayNotHasKey('x-body-eval', $headers);
-        $this->assertArrayNotHasKey('x-body-file', $headers);
+        $response = $client->request('GET', 'http://example.com/multi-chunk');
+        $content = '';
+        foreach ($client->stream($response) as $chunk) {
+            $content .= $chunk->getContent();
+        }
+        self::assertSame('chunk1chunk2chunk3', $content);
+
+        $response = $client->request('GET', 'http://example.com/multi-chunk');
+        $content = '';
+        foreach ($client->stream($response) as $chunk) {
+            $content .= $chunk->getContent();
+        }
+        self::assertSame('chunk1chunk2chunk3', $content);
     }
 
-    public function testDoesNotReadFile()
+    public function testConditionalCacheableStatusCodeWithoutExpiration()
     {
-        $file = __DIR__.'/Fixtures/assertion_failure.php';
+        $mockClient = new MockHttpClient([
+            new MockResponse('redirected', ['http_code' => 302]),
+            new MockResponse('new redirect', ['http_code' => 302]),
+        ]);
 
-        $response = $this->runRequest(new MockResponse(
-            'test', ['response_headers' => [
-                'X-Body-File' => $file,
-            ]]
-        ));
-        $headers = $response->getHeaders();
+        $client = new CachingHttpClient($mockClient, $this->cacheAdapter);
 
-        $this->assertSame('test', $response->getContent());
-        $this->assertArrayNotHasKey('x-body-file', $headers);
+        $response = $client->request('GET', 'http://example.com/redirect');
+        self::assertSame(302, $response->getStatusCode());
+        self::assertSame('redirected', $response->getContent(false));
+
+        $response = $client->request('GET', 'http://example.com/redirect');
+        self::assertSame(302, $response->getStatusCode());
+        self::assertSame('new redirect', $response->getContent(false));
     }
 
-    public function testRemovesXContentDigest()
+    public function testConditionalCacheableStatusCodeWithExpiration()
     {
-        $response = $this->runRequest(new MockResponse(
-            'test', [
+        $mockClient = new MockHttpClient([
+            new MockResponse('redirected', [
+                'http_code' => 302,
+                'response_headers' => ['Cache-Control' => 'max-age=5'],
+            ]),
+            new MockResponse('should not be served'),
+        ]);
+
+        $client = new CachingHttpClient($mockClient, $this->cacheAdapter);
+
+        $response = $client->request('GET', 'http://example.com/redirect');
+        self::assertSame(302, $response->getStatusCode());
+        self::assertSame('redirected', $response->getContent(false));
+
+        $response = $client->request('GET', 'http://example.com/redirect');
+        self::assertSame(302, $response->getStatusCode());
+        self::assertSame('redirected', $response->getContent(false));
+    }
+
+    public function testETagRevalidation()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', [
+                'http_code' => 200,
+                'response_headers' => ['ETag' => '"abc123"', 'Cache-Control' => 'max-age=5'],
+            ]),
+            new MockResponse('', ['http_code' => 304, 'response_headers' => ['ETag' => '"abc123"']]),
+        ]);
+
+        $client = new CachingHttpClient($mockClient, $this->cacheAdapter);
+
+        $response = $client->request('GET', 'http://example.com/etag');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('foo', $response->getContent());
+
+        sleep(6);
+
+        $response = $client->request('GET', 'http://example.com/etag');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('foo', $response->getContent());
+    }
+
+    public function testLastModifiedRevalidation()
+    {
+        $lastModified = 'Wed, 21 Oct 2015 07:28:00 GMT';
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', [
+                'http_code' => 200,
+                'response_headers' => ['Last-Modified' => $lastModified, 'Cache-Control' => 'max-age=5'],
+            ]),
+            new MockResponse('', ['http_code' => 304, 'response_headers' => ['Last-Modified' => $lastModified]]),
+        ]);
+
+        $client = new CachingHttpClient($mockClient, $this->cacheAdapter);
+
+        $response = $client->request('GET', 'http://example.com/last-modified');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('foo', $response->getContent());
+
+        sleep(6);
+
+        $response = $client->request('GET', 'http://example.com/last-modified');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('foo', $response->getContent());
+    }
+
+    public function testAgeCalculation()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', ['http_code' => 200, 'response_headers' => ['Cache-Control' => 'max-age=300']]),
+        ]);
+
+        $client = new CachingHttpClient($mockClient, $this->cacheAdapter);
+
+        $response = $client->request('GET', 'http://example.com/age-test');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('foo', $response->getContent());
+
+        sleep(3);
+
+        $response = $client->request('GET', 'http://example.com/age-test');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('foo', $response->getContent());
+        self::assertSame('3', $response->getHeaders()['age'][0]);
+    }
+
+    public function testGatewayTimeoutOnMustRevalidateFailure()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', [
+                'http_code' => 200,
+                'response_headers' => ['Cache-Control' => 'max-age=1, must-revalidate'],
+            ]),
+            new MockResponse('server error', ['http_code' => 500]),
+        ]);
+
+        $client = new CachingHttpClient($mockClient, $this->cacheAdapter);
+
+        $response = $client->request('GET', 'http://example.com/must-revalidate');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('foo', $response->getContent());
+
+        sleep(2);
+
+        $response = $client->request('GET', 'http://example.com/must-revalidate');
+        self::assertSame(504, $response->getStatusCode());
+    }
+
+    public function testVaryAsteriskPreventsCaching()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', ['http_code' => 200, 'response_headers' => ['Vary' => '*']]),
+            new MockResponse('bar', ['http_code' => 200]),
+        ]);
+
+        $client = new CachingHttpClient($mockClient, $this->cacheAdapter);
+
+        $response = $client->request('GET', 'http://example.com/vary-asterisk');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('foo', $response->getContent());
+
+        $response = $client->request('GET', 'http://example.com/vary-asterisk');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('bar', $response->getContent());
+    }
+
+    public function testExcludedHeadersAreNotCached()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', [
+                'http_code' => 200,
                 'response_headers' => [
-                    'X-Content-Digest' => 'some-hash',
+                    'Cache-Control' => 'max-age=300',
+                    'Connection' => 'keep-alive',
+                    'Proxy-Authenticate' => 'Basic',
+                    'Proxy-Authentication-Info' => 'info',
+                    'Proxy-Authorization' => 'Bearer token',
+                    'Content-Type' => 'text/plain',
+                    'X-Custom-Header' => 'custom-value',
                 ],
-            ]));
-        $headers = $response->getHeaders();
+            ]),
+            new MockResponse('should not be served', ['http_code' => 200]),
+        ]);
 
-        $this->assertArrayNotHasKey('x-content-digest', $headers);
+        $client = new CachingHttpClient($mockClient, $this->cacheAdapter);
+
+        $response = $client->request('GET', 'http://example.com/header-test');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('foo', $response->getContent());
+
+        $cachedResponse = $client->request('GET', 'http://example.com/header-test');
+        self::assertSame(200, $cachedResponse->getStatusCode());
+        self::assertSame('foo', $cachedResponse->getContent());
+
+        $cachedHeaders = $cachedResponse->getHeaders();
+
+        self::assertArrayNotHasKey('connection', $cachedHeaders);
+        self::assertArrayNotHasKey('proxy-authenticate', $cachedHeaders);
+        self::assertArrayNotHasKey('proxy-authentication-info', $cachedHeaders);
+        self::assertArrayNotHasKey('proxy-authorization', $cachedHeaders);
+
+        self::assertArrayHasKey('cache-control', $cachedHeaders);
+        self::assertArrayHasKey('content-type', $cachedHeaders);
+        self::assertArrayHasKey('x-custom-header', $cachedHeaders);
     }
 
-    private function runRequest(MockResponse $mockResponse): ResponseInterface
+    public function testHeuristicFreshnessWithLastModified()
     {
-        $mockClient = new MockHttpClient($mockResponse);
+        $lastModified = gmdate('D, d M Y H:i:s T', time() - 3600); // 1 hour ago
+        $mockClient = new MockHttpClient([
+            new MockResponse('foo', [
+                'http_code' => 200,
+                'response_headers' => ['Last-Modified' => $lastModified],
+            ]),
+            new MockResponse('bar'),
+        ]);
 
-        $store = new Store(sys_get_temp_dir().'/sf_http_cache');
-        $client = new CachingHttpClient($mockClient, $store);
+        $client = new CachingHttpClient($mockClient, $this->cacheAdapter);
 
-        $response = $client->request('GET', 'http://test');
+        // First request caches with heuristic
+        $response = $client->request('GET', 'http://example.com/heuristic');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('foo', $response->getContent());
 
-        return $response;
+        // Heuristic: 10% of 3600s = 360s; should be fresh within this time
+        sleep(360); // 5 minutes
+
+        $response = $client->request('GET', 'http://example.com/heuristic');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('foo', $response->getContent());
+
+        // After heuristic expires
+        sleep(1); // Total 361s, past 360s heuristic
+
+        $response = $client->request('GET', 'http://example.com/heuristic');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('bar', $response->getContent());
+    }
+
+    public function testResponseInfluencingHeadersAffectCacheKey()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('response for en', ['http_code' => 200]),
+            new MockResponse('response for fr', ['http_code' => 200]),
+        ]);
+
+        $client = new CachingHttpClient($mockClient, $this->cacheAdapter);
+
+        // First request with Accept-Language: en
+        $response = $client->request('GET', 'http://example.com/lang-test', ['headers' => ['Accept-Language' => 'en']]);
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('response for en', $response->getContent());
+
+        // Same request with Accept-Language: en should return cached response
+        $response = $client->request('GET', 'http://example.com/lang-test', ['headers' => ['Accept-Language' => 'en']]);
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('response for en', $response->getContent());
+
+        // Request with Accept-Language: fr should fetch new response
+        $response = $client->request('GET', 'http://example.com/lang-test', ['headers' => ['Accept-Language' => 'fr']]);
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('response for fr', $response->getContent());
+    }
+
+    public function testUnsafeInvalidationInBypassFlow()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('initial get', ['http_code' => 200, 'response_headers' => ['Cache-Control' => 'max-age=300']]),
+            new MockResponse('', ['http_code' => 204]),
+            new MockResponse('after invalidate', ['http_code' => 200]),
+        ]);
+
+        $client = new CachingHttpClient($mockClient, $this->cacheAdapter);
+
+        // Warm cache with GET
+        $response = $client->request('GET', 'http://example.com/unsafe-test');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('initial get', $response->getContent());
+
+        // Unsafe POST with body (bypasses cache but invalidates on success)
+        $client->request('POST', 'http://example.com/unsafe-test', ['body' => 'invalidate']);
+
+        // Next GET should miss cache and fetch new
+        $response = $client->request('GET', 'http://example.com/unsafe-test');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('after invalidate', $response->getContent());
+    }
+
+    public function testNoInvalidationOnErrorInBypassFlow()
+    {
+        $mockClient = new MockHttpClient([
+            new MockResponse('initial get', ['http_code' => 200, 'response_headers' => ['Cache-Control' => 'max-age=300']]),
+            new MockResponse('server error', ['http_code' => 500]),
+            new MockResponse('should not be fetched'),
+        ]);
+
+        $client = new CachingHttpClient($mockClient, $this->cacheAdapter);
+
+        // Warm cache with GET
+        $response = $client->request('GET', 'http://example.com/no-invalidate-test');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('initial get', $response->getContent());
+
+        // Unsafe POST with body (bypasses cache, but 500 shouldn't invalidate)
+        $response = $client->request('POST', 'http://example.com/no-invalidate-test', ['body' => 'no invalidate']);
+        self::assertSame(500, $response->getStatusCode());
+
+        // Next GET should hit cache
+        $response = $client->request('GET', 'http://example.com/no-invalidate-test');
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('initial get', $response->getContent());
     }
 }

--- a/src/Symfony/Component/HttpClient/Tests/LegacyCachingHttpClientTest.php
+++ b/src/Symfony/Component/HttpClient/Tests/LegacyCachingHttpClientTest.php
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\HttpClient\Tests;
+
+use PHPUnit\Framework\Attributes\Group;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\CachingHttpClient;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\HttpKernel\HttpCache\Store;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+#[IgnoreDeprecations]
+#[Group('legacy')]
+class LegacyCachingHttpClientTest extends TestCase
+{
+    public function testRequestHeaders()
+    {
+        $this->expectUserDeprecationMessage('Since symfony/http-client 7.4: Passing a "Symfony\Component\HttpKernel\HttpCache\StoreInterface" as constructor\'s 2nd argument of "Symfony\Component\HttpClient\CachingHttpClient" is deprecated, "Symfony\Contracts\Cache\TagAwareCacheInterface" expected.');
+
+        $options = [
+            'headers' => [
+                'Application-Name' => 'test1234',
+                'Test-Name-Header' => 'test12345',
+            ],
+        ];
+
+        $mockClient = new MockHttpClient();
+        $store = new Store(sys_get_temp_dir().'/sf_http_cache');
+        $client = new CachingHttpClient($mockClient, $store, $options);
+
+        $response = $client->request('GET', 'http://example.com/foo-bar');
+
+        rmdir(sys_get_temp_dir().'/sf_http_cache');
+        self::assertInstanceOf(MockResponse::class, $response);
+        self::assertSame($response->getRequestOptions()['normalized_headers']['application-name'][0], 'Application-Name: test1234');
+        self::assertSame($response->getRequestOptions()['normalized_headers']['test-name-header'][0], 'Test-Name-Header: test12345');
+    }
+
+    public function testDoesNotEvaluateResponseBody()
+    {
+        $this->expectUserDeprecationMessage('Since symfony/http-client 7.4: Passing a "Symfony\Component\HttpKernel\HttpCache\StoreInterface" as constructor\'s 2nd argument of "Symfony\Component\HttpClient\CachingHttpClient" is deprecated, "Symfony\Contracts\Cache\TagAwareCacheInterface" expected.');
+
+        $body = file_get_contents(__DIR__.'/Fixtures/assertion_failure.php');
+        $response = $this->runRequest(new MockResponse($body, ['response_headers' => ['X-Body-Eval' => true]]));
+        $headers = $response->getHeaders();
+
+        $this->assertSame($body, $response->getContent());
+        $this->assertArrayNotHasKey('x-body-eval', $headers);
+    }
+
+    public function testDoesNotIncludeFile()
+    {
+        $this->expectUserDeprecationMessage('Since symfony/http-client 7.4: Passing a "Symfony\Component\HttpKernel\HttpCache\StoreInterface" as constructor\'s 2nd argument of "Symfony\Component\HttpClient\CachingHttpClient" is deprecated, "Symfony\Contracts\Cache\TagAwareCacheInterface" expected.');
+
+        $file = __DIR__.'/Fixtures/assertion_failure.php';
+
+        $response = $this->runRequest(new MockResponse(
+            'test', ['response_headers' => [
+                'X-Body-Eval' => true,
+                'X-Body-File' => $file,
+            ]]
+        ));
+        $headers = $response->getHeaders();
+
+        $this->assertSame('test', $response->getContent());
+        $this->assertArrayNotHasKey('x-body-eval', $headers);
+        $this->assertArrayNotHasKey('x-body-file', $headers);
+    }
+
+    public function testDoesNotReadFile()
+    {
+        $this->expectUserDeprecationMessage('Since symfony/http-client 7.4: Passing a "Symfony\Component\HttpKernel\HttpCache\StoreInterface" as constructor\'s 2nd argument of "Symfony\Component\HttpClient\CachingHttpClient" is deprecated, "Symfony\Contracts\Cache\TagAwareCacheInterface" expected.');
+
+        $file = __DIR__.'/Fixtures/assertion_failure.php';
+
+        $response = $this->runRequest(new MockResponse(
+            'test', ['response_headers' => [
+                'X-Body-File' => $file,
+            ]]
+        ));
+        $headers = $response->getHeaders();
+
+        $this->assertSame('test', $response->getContent());
+        $this->assertArrayNotHasKey('x-body-file', $headers);
+    }
+
+    public function testRemovesXContentDigest()
+    {
+        $this->expectUserDeprecationMessage('Since symfony/http-client 7.4: Passing a "Symfony\Component\HttpKernel\HttpCache\StoreInterface" as constructor\'s 2nd argument of "Symfony\Component\HttpClient\CachingHttpClient" is deprecated, "Symfony\Contracts\Cache\TagAwareCacheInterface" expected.');
+
+        $response = $this->runRequest(new MockResponse(
+            'test', [
+                'response_headers' => [
+                    'X-Content-Digest' => 'some-hash',
+                ],
+            ]));
+        $headers = $response->getHeaders();
+
+        $this->assertArrayNotHasKey('x-content-digest', $headers);
+    }
+
+    private function runRequest(MockResponse $mockResponse): ResponseInterface
+    {
+        $mockClient = new MockHttpClient($mockResponse);
+
+        $store = new Store(sys_get_temp_dir().'/sf_http_cache');
+        $client = new CachingHttpClient($mockClient, $store);
+
+        $response = $client->request('GET', 'http://test');
+
+        return $response;
+    }
+}

--- a/src/Symfony/Component/HttpClient/composer.json
+++ b/src/Symfony/Component/HttpClient/composer.json
@@ -37,6 +37,7 @@
         "php-http/httplug": "^1.0|^2.0",
         "psr/http-client": "^1.0",
         "symfony/amphp-http-client-meta": "^1.0|^2.0",
+        "symfony/cache": "^6.4|^7.0|^8.0",
         "symfony/dependency-injection": "^6.4|^7.0|^8.0",
         "symfony/http-kernel": "^6.4|^7.0|^8.0",
         "symfony/messenger": "^6.4|^7.0|^8.0",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RFC 9111-compliant HTTP client caching with configurable cache pools, shared/private cache options, and maximum TTL settings.
  * Support for response freshness evaluation, revalidation, and Vary header handling.

* **Documentation**
  * Updated HTTP client configuration schema and changelog entries documenting caching support.

* **Deprecations**
  * Deprecated passing `StoreInterface` instance to `CachingHttpClient` constructor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->